### PR TITLE
[HCFRO-311] - Log everything to /var/vcap/sys/log/

### DIFF
--- a/bosh-release/jobs/autoscaler_api/spec
+++ b/bosh-release/jobs/autoscaler_api/spec
@@ -3,6 +3,7 @@ name: autoscaler_api
 templates:
   tomcat_ctl: bin/tomcat_ctl
   server.xml: conf/server.xml
+  logging.properties: conf/logging.properties
 packages:
   - pid_utils
   - java

--- a/bosh-release/jobs/autoscaler_api/templates/logging.properties
+++ b/bosh-release/jobs/autoscaler_api/templates/logging.properties
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+
+2localhost.org.apache.juli.AsyncFileHandler.level = FINE
+2localhost.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+
+3manager.org.apache.juli.AsyncFileHandler.level = FINE
+3manager.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
+4host-manager.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE

--- a/bosh-release/jobs/autoscaler_api/templates/server.xml
+++ b/bosh-release/jobs/autoscaler_api/templates/server.xml
@@ -132,7 +132,7 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/tomcat"
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 

--- a/bosh-release/jobs/autoscaler_api/templates/tomcat_ctl
+++ b/bosh-release/jobs/autoscaler_api/templates/tomcat_ctl
@@ -23,7 +23,7 @@ case $1 in
 
     #config server.xml
     cp /var/vcap/jobs/${BASE_NAME}/conf/server.xml /var/vcap/packages/tomcat/conf/server.xml
-    exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/$tomcat.stderr.log 
+    exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/tomcat.stderr.log 
     ;;
 
   stop)

--- a/bosh-release/jobs/autoscaler_api/templates/tomcat_ctl
+++ b/bosh-release/jobs/autoscaler_api/templates/tomcat_ctl
@@ -11,6 +11,7 @@ source /var/vcap/packages/pid_utils/pid_utils.sh
 
 export JAVA_HOME=/var/vcap/packages/java/jdk
 export CATALINA_PID=$PIDFILE
+export CATALINA_OUT=${LOG_DIR}/catalina.out
 
 case $1 in
 
@@ -20,6 +21,9 @@ case $1 in
     mkdir -p $LOG_DIR
 
     cp -r /var/vcap/packages/${BASE_NAME}/api /var/vcap/packages/tomcat/webapps
+    
+    #configure logging
+    cp /var/vcap/jobs/${BASE_NAME}/conf/logging.properties /var/vcap/packages/tomcat/conf/logging.properties
 
     #config server.xml
     cp /var/vcap/jobs/${BASE_NAME}/conf/server.xml /var/vcap/packages/tomcat/conf/server.xml

--- a/bosh-release/jobs/autoscaler_server/spec
+++ b/bosh-release/jobs/autoscaler_server/spec
@@ -3,6 +3,7 @@ name: autoscaler_server
 templates:
   tomcat_ctl: bin/tomcat_ctl
   server.xml: conf/server.xml
+  logging.properties: conf/logging.properties
 packages:
   - pid_utils
   - java

--- a/bosh-release/jobs/autoscaler_server/templates/logging.properties
+++ b/bosh-release/jobs/autoscaler_server/templates/logging.properties
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+
+2localhost.org.apache.juli.AsyncFileHandler.level = FINE
+2localhost.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+
+3manager.org.apache.juli.AsyncFileHandler.level = FINE
+3manager.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
+4host-manager.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE

--- a/bosh-release/jobs/autoscaler_server/templates/server.xml
+++ b/bosh-release/jobs/autoscaler_server/templates/server.xml
@@ -132,7 +132,7 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/tomcat"
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 

--- a/bosh-release/jobs/autoscaler_server/templates/tomcat_ctl
+++ b/bosh-release/jobs/autoscaler_server/templates/tomcat_ctl
@@ -11,6 +11,7 @@ source /var/vcap/packages/pid_utils/pid_utils.sh
 
 export JAVA_HOME=/var/vcap/packages/java/jdk
 export CATALINA_PID=$PIDFILE
+export CATALINA_OUT=${LOG_DIR}/catalina.out
 
 case $1 in
 
@@ -23,6 +24,9 @@ case $1 in
 
     #config server.xml
     cp /var/vcap/jobs/${BASE_NAME}/conf/server.xml /var/vcap/packages/tomcat/conf/server.xml
+    
+    #configure logging
+    cp /var/vcap/jobs/${BASE_NAME}/conf/logging.properties /var/vcap/packages/tomcat/conf/logging.properties
 
     exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/tomcat.stderr.log 
     ;;

--- a/bosh-release/jobs/autoscaler_server/templates/tomcat_ctl
+++ b/bosh-release/jobs/autoscaler_server/templates/tomcat_ctl
@@ -24,7 +24,7 @@ case $1 in
     #config server.xml
     cp /var/vcap/jobs/${BASE_NAME}/conf/server.xml /var/vcap/packages/tomcat/conf/server.xml
 
-    exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/$tomcat.stderr.log 
+    exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/tomcat.stderr.log 
     ;;
 
   stop)

--- a/bosh-release/jobs/autoscaler_servicebroker/spec
+++ b/bosh-release/jobs/autoscaler_servicebroker/spec
@@ -3,6 +3,7 @@ name: autoscaler_servicebroker
 templates:
   tomcat_ctl: bin/tomcat_ctl
   server.xml: conf/server.xml
+  logging.properties: conf/logging.properties
 packages:
   - pid_utils
   - java

--- a/bosh-release/jobs/autoscaler_servicebroker/templates/logging.properties
+++ b/bosh-release/jobs/autoscaler_servicebroker/templates/logging.properties
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handlers = 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+1catalina.org.apache.juli.AsyncFileHandler.level = FINE
+1catalina.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.
+
+2localhost.org.apache.juli.AsyncFileHandler.level = FINE
+2localhost.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+2localhost.org.apache.juli.AsyncFileHandler.prefix = localhost.
+
+3manager.org.apache.juli.AsyncFileHandler.level = FINE
+3manager.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+3manager.org.apache.juli.AsyncFileHandler.prefix = manager.
+
+4host-manager.org.apache.juli.AsyncFileHandler.level = FINE
+4host-manager.org.apache.juli.AsyncFileHandler.directory = /var/vcap/sys/log/tomcat
+4host-manager.org.apache.juli.AsyncFileHandler.prefix = host-manager.
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter
+
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = 2localhost.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/manager].handlers = 3manager.org.apache.juli.AsyncFileHandler
+
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].level = INFO
+org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/host-manager].handlers = 4host-manager.org.apache.juli.AsyncFileHandler
+
+# For example, set the org.apache.catalina.util.LifecycleBase logger to log
+# each component that extends LifecycleBase changing state:
+#org.apache.catalina.util.LifecycleBase.level = FINE
+
+# To see debug messages in TldLocationsCache, uncomment the following line:
+#org.apache.jasper.compiler.TldLocationsCache.level = FINE

--- a/bosh-release/jobs/autoscaler_servicebroker/templates/server.xml
+++ b/bosh-release/jobs/autoscaler_servicebroker/templates/server.xml
@@ -132,7 +132,7 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/vcap/sys/log/tomcat"
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 

--- a/bosh-release/jobs/autoscaler_servicebroker/templates/tomcat_ctl
+++ b/bosh-release/jobs/autoscaler_servicebroker/templates/tomcat_ctl
@@ -11,6 +11,7 @@ source /var/vcap/packages/pid_utils/pid_utils.sh
 
 export JAVA_HOME=/var/vcap/packages/java/jdk
 export CATALINA_PID=$PIDFILE
+export CATALINA_OUT=${LOG_DIR}/catalina.out
 
 case $1 in
 
@@ -23,6 +24,9 @@ case $1 in
 
     #config server.xml
     cp /var/vcap/jobs/${BASE_NAME}/conf/server.xml /var/vcap/packages/tomcat/conf/server.xml
+    
+    #configure logging
+    cp /var/vcap/jobs/${BASE_NAME}/conf/logging.properties /var/vcap/packages/tomcat/conf/logging.properties
 
     exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/tomcat.stderr.log 
     ;;

--- a/bosh-release/jobs/autoscaler_servicebroker/templates/tomcat_ctl
+++ b/bosh-release/jobs/autoscaler_servicebroker/templates/tomcat_ctl
@@ -24,7 +24,7 @@ case $1 in
     #config server.xml
     cp /var/vcap/jobs/${BASE_NAME}/conf/server.xml /var/vcap/packages/tomcat/conf/server.xml
 
-    exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/$tomcat.stderr.log 
+    exec /var/vcap/packages/tomcat/bin/catalina.sh start  > $LOG_DIR/tomcat.stdout.log 2> $LOG_DIR/tomcat.stderr.log 
     ;;
 
   stop)


### PR DESCRIPTION
Move log information for api, service and broker to /var/vcap/sys/log 
log information that was moved:
- tomcat accesslog
- catalina output file
- other logging informatin
