### PR TITLE
Add missing properties to BOSH specs

### DIFF
--- a/bosh-release/jobs/autoscaler_api/spec
+++ b/bosh-release/jobs/autoscaler_api/spec
@@ -22,3 +22,5 @@ properties:
         description: the autoscaler-API's password
   autoscaler_api.scaling_service.name:
         description: the autoscaler service name
+  uaa.clients.cf-autoscaler-client.secret:
+        description: OAuth2 client secret for the autoscaler

--- a/bosh-release/jobs/autoscaler_server/spec
+++ b/bosh-release/jobs/autoscaler_server/spec
@@ -15,4 +15,19 @@ properties:
     default: 80
   autoscaler.couchdb.host:
     description: the network host for the couchdb server
-  
+  autoscaler_server.internal_auth.username:
+        description: the autoscaler-Server's username
+  autoscaler_server.internal_auth.password:
+        description: the autoscaler-Server's password
+  couchdb.host:
+    description: Host name of couchdb server
+  couchdb.password:
+    description: Password to connect to couchdb
+  couchdb.port:
+    description: Port of couchdb server
+  couchdb.username:
+    description: User name to connect to couchdb
+  system_domain:
+    description: The system domain
+  uaa.clients.cf-autoscaler-client.secret:
+        description: OAuth2 client secret for the autoscaler

--- a/bosh-release/jobs/autoscaler_servicebroker/spec
+++ b/bosh-release/jobs/autoscaler_servicebroker/spec
@@ -31,6 +31,14 @@ properties:
     default: CF-AutoScaler
   couchdb.dbname:
     description: couchdb dbname
+  couchdb.host:
+    description: Host name of couchdb server
+  couchdb.password:
+    description: Password to connect to couchdb
+  couchdb.port:
+    description: Port of couchdb server
+  couchdb.username:
+    description: User name to connect to couchdb
   tomcat.http.autoscaler_api.port:
     description: api port
   tomcat.http.autoscaler_api.route:


### PR DESCRIPTION
This is required to correctly execute the jobs.  All the secrets were missing.
